### PR TITLE
Feature/cli and library support

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -19,6 +19,10 @@ UV_LINK_MODE = "copy"
 description = "Run the awsbreaker app"
 run = "uv run python -m awsbreaker.main"
 
+[tasks.cli]
+description = "Run the AWSBreaker CLI (Typer) from local source"
+run = "uv run python -m awsbreaker.cli"
+
 [tasks.test]
 description = "Run unit tests"
 run = "uv run pytest -q"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,19 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "hyperoot", email = "rajesh@hyperoot.dev" }]
 requires-python = ">=3.13"
-dependencies = ["boto3>=1.40.1", "pyfiglet>=1.0.3", "pyyaml>=6.0.2"]
+dependencies = [
+    "boto3>=1.40.1",
+    "pyfiglet>=1.0.3",
+    "pyyaml>=6.0.2",
+    "rich>=14.1.0",
+    "typer>=0.16.0",
+]
 
 [dependency-groups]
 dev = ["pytest>=8.4.1", "pytest-cov>=6.2.1", "ruff>=0.12.7"]
 
 [project.scripts]
-awsbreaker = "awsbreaker.main:main"
+awsbreaker = "awsbreaker.cli:app"
 
 [build-system]
 requires = ["uv_build>=0.8.4,<0.9.0"]

--- a/src/awsbreaker/__init__.py
+++ b/src/awsbreaker/__init__.py
@@ -1,3 +1,5 @@
+from awsbreaker.conf.config import get_config
 from awsbreaker.logger import setup_logging
+from awsbreaker.main import run
 
-__all__ = ["setup_logging"]
+__all__ = ["run", "get_config", "setup_logging"]

--- a/src/awsbreaker/cli.py
+++ b/src/awsbreaker/cli.py
@@ -1,0 +1,144 @@
+import sys
+
+import typer
+
+from awsbreaker.conf.config import get_config
+from awsbreaker.logger import setup_logging
+from awsbreaker.orchestrator import orchestrate_services
+
+app = typer.Typer(help="AWSBreaker — kill-switch for AWS resources when spending limits are breached.")
+
+
+def run_cli(dry_run: bool | None, verbose: bool | None, no_progress: bool) -> None:
+    """Execute the CLI flow with presentation, progress, and summary."""
+    # Merge CLI overrides into config so logging respects verbosity
+    overrides = {"dry_run": dry_run, "verbose": verbose}
+    config = get_config(cli_args=overrides)
+    setup_logging(config)
+
+    # Resolve effective flags
+    dry_run_eff = dry_run if dry_run is not None else getattr(config, "dry_run", True)
+    verbose_eff = verbose if verbose is not None else bool(getattr(config, "verbose", False))
+
+    # Lazy import rich; fall back to plain print if unavailable
+    try:
+        from rich.console import Console
+
+        console = Console()
+    except Exception:
+        console = None
+
+    # Header / credits (CLI only)
+    try:
+        import pyfiglet
+
+        if not verbose_eff:
+            banner = pyfiglet.figlet_format("AWSBreaker", font="slant")
+            if console:
+                console.print(banner.rstrip())
+                console.print("\nby HYP3R00T  |  https://hyperoot.dev  |  https://github.com/HYP3R00T")
+                console.print()
+            else:
+                print(banner.rstrip())
+                print("\nby HYP3R00T  |  https://hyperoot.dev  |  https://github.com/HYP3R00T")
+                print()
+        else:
+            if console:
+                console.print("Starting AWSBreaker")
+            else:
+                print("Starting AWSBreaker")
+    except Exception:
+        if console:
+            console.print("AWSBreaker")
+            console.print("by HYP3R00T  |  https://hyperoot.dev  |  https://github.com/HYP3R00T")
+            console.print()
+        else:
+            print("AWSBreaker")
+            print("by HYP3R00T  |  https://hyperoot.dev  |  https://github.com/HYP3R00T")
+            print()
+
+    if console:
+        console.print(f"Mode: {'DRY-RUN' if dry_run_eff else 'EXECUTE'}\n")
+    else:
+        print(f"Mode: {'DRY-RUN' if dry_run_eff else 'EXECUTE'}\n")
+
+    # Progress callback for non-verbose mode
+    last_len = 0
+
+    def progress_cb(stats: dict[str, int]) -> None:
+        if no_progress or verbose_eff:
+            return
+        nonlocal last_len
+        submitted = stats.get("submitted", 0)
+        completed = stats.get("completed", 0)
+        pending = stats.get("pending", 0)
+        failures = stats.get("failures", 0)
+        succeeded = stats.get("succeeded", 0)
+        deletions = stats.get("deletions", 0)
+        line = (
+            f"Progress: completed={completed}/{submitted} pending={pending} "
+            f"succeeded={succeeded} failures={failures} deletions={deletions}"
+        )
+        padded = line.ljust(last_len)
+        sys.stdout.write("\r" + padded)
+        sys.stdout.flush()
+        last_len = len(line)
+
+    summary = orchestrate_services(dry_run=dry_run_eff, progress_cb=progress_cb, print_summary=False)
+
+    if not no_progress and not verbose_eff and last_len > 0:
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
+    # Final summary
+    submitted = summary.get("submitted", 0)
+    skipped = summary.get("skipped", 0)
+    failures = summary.get("failures", 0)
+    succeeded = summary.get("succeeded", 0)
+    deletions = summary.get("deletions", 0)
+
+    if console:
+        console.print("\n[bold]Run Summary[/bold]")
+        console.print("-----------")
+        console.print(f"Tasks submitted   : {submitted}")
+        console.print(f"Tasks skipped     : {skipped}")
+        console.print(f"Tasks failed      : {failures}")
+        console.print(f"Tasks succeeded   : {succeeded}")
+        console.print(f"Total deletions   : {deletions}")
+    else:
+        print("\nRun Summary")
+        print("-----------")
+        print(f"Tasks submitted   : {submitted}")
+        print(f"Tasks skipped     : {skipped}")
+        print(f"Tasks failed      : {failures}")
+        print(f"Tasks succeeded   : {succeeded}")
+        print(f"Total deletions   : {deletions}")
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    dry_run: bool | None = typer.Option(
+        None,
+        "--dry-run/--execute",
+        help="Run in dry-run mode (default from config). Use --execute to actually delete resources.",
+    ),
+    verbose: bool | None = typer.Option(
+        None,
+        "--verbose/--quiet",
+        help="Enable verbose logging (default from config).",
+    ),
+    no_progress: bool = typer.Option(
+        False,
+        "--no-progress",
+        is_flag=True,
+        help="Disable the compact live progress line.",
+    ),
+):
+    """
+    Runs AWSBreaker. If subcommands are added later, this acts as the default.
+    """
+    run_cli(dry_run=dry_run, verbose=verbose, no_progress=no_progress)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/awsbreaker/conf/config.yaml
+++ b/src/awsbreaker/conf/config.yaml
@@ -1,4 +1,4 @@
-dry_run: false
+dry_run: true
 verbose: false # when true, enables console logs; level is controlled by logging.level
 logging:
   level: INFO

--- a/src/awsbreaker/main.py
+++ b/src/awsbreaker/main.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from typing import Any
 
 from awsbreaker.conf.config import get_config
@@ -9,87 +8,35 @@ from awsbreaker.orchestrator import orchestrate_services
 logger = logging.getLogger(__name__)
 
 
-def _print_header(verbose: bool) -> None:
-    """Pretty header for non-verbose mode; simple print when verbose."""
-    try:
-        import pyfiglet  # type: ignore
+def run(dry_run: bool | None = None) -> dict[str, Any]:
+    """
+    Programmatic API to execute AWSBreaker without printing to stdout.
 
-        if not verbose:
-            banner = pyfiglet.figlet_format("AWSBreaker", font="slant")
-            print(banner.rstrip())
-            print("\nby HYP3R00T  |  https://hyperoot.dev  |  https://github.com/HYP3R00T")
-            print()
-        else:
-            print("Starting AWSBreaker")
-    except Exception:
-        # Fallback to minimal header if pyfiglet missing or fails
-        print("AWSBreaker")
-        print("by HYP3R00T  |  https://hyperoot.dev  |  https://github.com/HYP3R00T")
-        print()
+    This function loads config, initializes logging, executes orchestration,
+    and returns a summary dict. All user-facing presentation (headers,
+    progress, summaries) should be handled by the CLI or the caller.
 
+    Args:
+        dry_run: Override dry-run mode. If None, uses value from config.
 
-def _print_summary(summary: dict[str, Any], verbose: bool) -> None:
-    """Organized multi-line summary for the whole run."""
-    submitted = summary.get("submitted", 0)
-    skipped = summary.get("skipped", 0)
-    failures = summary.get("failures", 0)
-    succeeded = summary.get("succeeded", 0)
-    deletions = summary.get("deletions", 0)
-
-    print("\nRun Summary")
-    print("-----------")
-    print(f"Tasks submitted   : {submitted}")
-    print(f"Tasks skipped     : {skipped}")
-    print(f"Tasks failed      : {failures}")
-    print(f"Tasks succeeded   : {succeeded}")
-    print(f"Total deletions   : {deletions}")
-    if verbose:
-        print("(Verbose logging enabled — see log for detailed events)")
-
-
-def main() -> None:
+    Returns:
+        A summary dict with counters for the run.
+    """
     # Load configuration and initialize logging first
     config = get_config()
     setup_logging(config)
 
-    dry_run = getattr(config, "dry_run", True)
-    verbose = bool(getattr(config, "verbose", False))
+    # Resolve effective flags (config > defaults, with optional override)
+    dry_run_eff = dry_run if dry_run is not None else getattr(config, "dry_run", True)
 
-    # Pretty header / credits
-    _print_header(verbose)
-    print(f"Mode: {'DRY-RUN' if dry_run else 'EXECUTE'}\n")
+    # Execute without progress reporting or printing; rely on logging instead
+    summary = orchestrate_services(dry_run=dry_run_eff, progress_cb=None, print_summary=False)
+    return summary
 
-    # Live progress for non-verbose mode: print compact counts as tasks finish
-    progress_last: dict[str, Any] | None = None
-    progress_last_len: int = 0
 
-    def progress_cb(stats: dict[str, int]) -> None:
-        nonlocal progress_last
-        progress_last = stats
-        if not verbose:
-            submitted = stats.get("submitted", 0)
-            completed = stats.get("completed", 0)
-            pending = stats.get("pending", 0)
-            failures = stats.get("failures", 0)
-            succeeded = stats.get("succeeded", 0)
-            deletions = stats.get("deletions", 0)
-            line = (
-                f"Progress: completed={completed}/{submitted} pending={pending} "
-                f"succeeded={succeeded} failures={failures} deletions={deletions}"
-            )
-            # Overwrite the same line in-place; pad with spaces to clear remnants
-            nonlocal progress_last_len
-            padded = line.ljust(progress_last_len)
-            sys.stdout.write("\r" + padded)
-            sys.stdout.flush()
-            progress_last_len = len(line)
-
-    summary = orchestrate_services(dry_run=dry_run, progress_cb=progress_cb, print_summary=False)
-    if not verbose and progress_last_len > 0:
-        # Move to the next line before final summary output
-        sys.stdout.write("\n")
-        sys.stdout.flush()
-    _print_summary(summary, verbose)
+def main() -> None:
+    # Minimal __main__ execution: no printing, just run with defaults
+    run()
 
 
 if __name__ == "__main__":

--- a/src/awsbreaker/orchestrator.py
+++ b/src/awsbreaker/orchestrator.py
@@ -222,13 +222,6 @@ def orchestrate_services(
                         "pending": max(0, len(future_map) - completed),
                     })
 
-    # Here, "succeeded" means tasks that actually deleted at least one resource.
-    # This excludes skipped tasks and no-op runs (e.g., nothing to delete or dry-run).
-    if print_summary:
-        print(
-            f"Summary => submitted={submitted}, skipped={skipped}, failures={failures}, succeeded={succeeded}, deletions={deletions_total}"
-        )
-
     return {
         "submitted": submitted,
         "skipped": skipped,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,168 @@
+import sys
+from types import SimpleNamespace
+
+
+class DummyConsole:
+    def __init__(self):
+        self.lines: list[str] = []
+
+    def print(self, *args, **kwargs):  # noqa: D401, ARG002
+        self.lines.append(" ".join(str(a) for a in args))
+
+
+def test_cli_run_flow_progress_and_summary(monkeypatch, capsys):
+    # Patch config and logging
+    cfg = SimpleNamespace(dry_run=True, verbose=False)
+
+    def fake_get_config(cli_args=None):  # noqa: D401, ARG001
+        # emulate config object with attributes used in cli.run_cli
+        return SimpleNamespace(dry_run=cfg.dry_run, verbose=cfg.verbose, aws=SimpleNamespace())
+
+    def fake_setup_logging(_cfg):  # noqa: D401, ARG001
+        return None
+
+    # patch orchestrate_services to simulate work and exercise progress callback
+    def fake_orchestrate_services(*, dry_run, progress_cb, print_summary):  # noqa: D401
+        assert dry_run is True
+        assert print_summary is False
+        # simulate two updates and final summary
+        if progress_cb:
+            progress_cb({
+                "submitted": 2,
+                "skipped": 0,
+                "failures": 0,
+                "succeeded": 0,
+                "deletions": 0,
+                "completed": 0,
+                "pending": 2,
+            })
+            progress_cb({
+                "submitted": 2,
+                "skipped": 0,
+                "failures": 0,
+                "succeeded": 1,
+                "deletions": 1,
+                "completed": 2,
+                "pending": 0,
+            })
+        return {"submitted": 2, "skipped": 0, "failures": 0, "succeeded": 1, "deletions": 1}
+
+    import awsbreaker.cli as cli
+
+    # Avoid importing rich/pyfiglet to keep output deterministic
+    monkeypatch.setitem(sys.modules, "rich.console", None)
+    monkeypatch.setitem(sys.modules, "pyfiglet", None)
+
+    monkeypatch.setattr(cli, "get_config", fake_get_config)
+    monkeypatch.setattr(cli, "setup_logging", fake_setup_logging)
+    monkeypatch.setattr(cli, "orchestrate_services", fake_orchestrate_services)
+
+    # run with no_progress False to exercise progress line; verbose=False ensures banner path
+    cli.run_cli(dry_run=True, verbose=False, no_progress=False)
+
+    out = capsys.readouterr().out
+    assert "Mode: DRY-RUN" in out
+    assert "Run Summary" in out
+    assert "Tasks submitted" in out
+
+
+def test_cli_with_console_and_verbose_banner(monkeypatch, capsys):
+    import awsbreaker.cli as cli
+
+    # Provide a dummy Console implementation via the rich.console module
+    class ConsoleModule:
+        class Console:  # noqa: D401
+            def __init__(self):
+                self.lines = []
+
+            def print(self, *args, **kwargs):  # noqa: D401, ARG002
+                # mimic console printing by writing to stdout
+                print(" ".join(str(a) for a in args))
+
+    # Provide a dummy pyfiglet with figlet_format
+    class PyFigletModule:
+        @staticmethod
+        def figlet_format(text, font=None):  # noqa: D401, ARG002
+            return f"BANNER:{text}"
+
+    monkeypatch.setitem(sys.modules, "rich.console", ConsoleModule)
+    monkeypatch.setitem(sys.modules, "pyfiglet", PyFigletModule)
+
+    # Config verbose False triggers banner path
+    def fake_get_config(cli_args=None):  # noqa: D401, ARG001
+        return SimpleNamespace(dry_run=True, verbose=False, aws=SimpleNamespace())
+
+    def fake_setup_logging(_cfg):
+        return None
+
+    def fake_orchestrate_services(*, dry_run, progress_cb, print_summary):  # noqa: D401, ARG002
+        assert dry_run is True
+        # call progress once to ensure callback doesn't explode with console present
+        if progress_cb:
+            progress_cb({
+                "submitted": 1,
+                "skipped": 0,
+                "failures": 0,
+                "succeeded": 0,
+                "deletions": 0,
+                "completed": 0,
+                "pending": 1,
+            })
+        return {"submitted": 1, "skipped": 0, "failures": 0, "succeeded": 0, "deletions": 0}
+
+    monkeypatch.setattr(cli, "get_config", fake_get_config)
+    monkeypatch.setattr(cli, "setup_logging", fake_setup_logging)
+    monkeypatch.setattr(cli, "orchestrate_services", fake_orchestrate_services)
+
+    cli.run_cli(dry_run=True, verbose=None, no_progress=True)
+    out = capsys.readouterr().out
+    assert "BANNER:AWSBreaker" in out
+    assert "Mode: DRY-RUN" in out
+    assert "Run Summary" in out
+
+
+def test_cli_verbose_quiet_flags_override(monkeypatch, capsys):
+    import awsbreaker.cli as cli
+
+    # Config defaults verbose=True, but cli overrides to quiet
+    cfg = SimpleNamespace(dry_run=False, verbose=True)
+
+    def fake_get_config(cli_args=None):  # noqa: D401, ARG001
+        return SimpleNamespace(dry_run=cfg.dry_run, verbose=cfg.verbose, aws=SimpleNamespace())
+
+    def fake_setup_logging(_cfg):
+        return None
+
+    def fake_orchestrate_services(*, dry_run, progress_cb, print_summary):  # noqa: D401, ARG002
+        assert dry_run is False
+        assert progress_cb is not None  # still created, but will be a no-op due to verbose
+        return {"submitted": 0, "skipped": 0, "failures": 0, "succeeded": 0, "deletions": 0}
+
+    monkeypatch.setitem(sys.modules, "rich.console", None)
+    monkeypatch.setitem(sys.modules, "pyfiglet", None)
+
+    monkeypatch.setattr(cli, "get_config", fake_get_config)
+    monkeypatch.setattr(cli, "setup_logging", fake_setup_logging)
+    monkeypatch.setattr(cli, "orchestrate_services", fake_orchestrate_services)
+
+    # verbose flag is None so it should read from cfg (True) and take the verbose path
+    cli.run_cli(dry_run=False, verbose=None, no_progress=True)
+
+    out = capsys.readouterr().out
+    # In verbose mode there should still be a summary header printed at the end
+    assert "Run Summary" in out
+
+
+def test_typer_callback_invokes_run_cli(monkeypatch):
+    import awsbreaker.cli as cli
+
+    called = {"ok": False}
+
+    def fake_run_cli(dry_run, verbose, no_progress):  # noqa: D401, ARG001
+        called["ok"] = True
+
+    monkeypatch.setattr(cli, "run_cli", fake_run_cli)
+
+    # Call the Typer callback directly with options
+    cli.main(dry_run=None, verbose=None, no_progress=False)
+    assert called["ok"] is True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+
+def test_run_calls_orchestrate_with_effective_dry_run(monkeypatch):
+    calls: dict[str, object] = {}
+
+    # Fake config returned by get_config
+    cfg = SimpleNamespace(dry_run=False)
+
+    def fake_get_config():
+        return cfg
+
+    def fake_setup_logging(_cfg):
+        calls["logging"] = True
+
+    def fake_orchestrate_services(*, dry_run, progress_cb, print_summary):  # noqa: D401
+        # Capture parameters to validate behavior
+        calls["dry_run"] = dry_run
+        calls["progress_cb"] = progress_cb
+        calls["print_summary"] = print_summary
+        return {"submitted": 0, "skipped": 0, "failures": 0, "succeeded": 0, "deletions": 0}
+
+    import awsbreaker.main as m
+
+    monkeypatch.setattr(m, "get_config", fake_get_config)
+    monkeypatch.setattr(m, "setup_logging", fake_setup_logging)
+    monkeypatch.setattr(m, "orchestrate_services", fake_orchestrate_services)
+
+    # Override dry_run to True and ensure it is passed through
+    out = m.run(dry_run=True)
+    assert out["submitted"] == 0
+    assert calls["dry_run"] is True
+    assert calls["progress_cb"] is None
+    assert calls["print_summary"] is False
+
+
+def test_main_invokes_run(monkeypatch):
+    import awsbreaker.main as m
+
+    invoked = {"run": False}
+
+    def fake_run(dry_run=None):  # noqa: D401, ARG001
+        invoked["run"] = True
+        return {}
+
+    monkeypatch.setattr(m, "run", fake_run)
+
+    # Should not raise and should call run()
+    m.main()
+    assert invoked["run"] is True

--- a/tests/test_orchestrator_functional.py
+++ b/tests/test_orchestrator_functional.py
@@ -1,0 +1,125 @@
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import awsbreaker.orchestrator as orch
+
+
+def test_functional_entrypoint_success_and_progress(monkeypatch, caplog):
+    # Configure single service and region
+    cfg = SimpleNamespace(aws=SimpleNamespace(services=["funcsvc"], region=["us-east-1"]))
+
+    class FakeSession:
+        def get_available_regions(self, service_name: str):  # noqa: D401, ARG002
+            return ["us-east-1"]
+
+    monkeypatch.setattr(orch, "get_config", lambda: cfg)
+    monkeypatch.setattr(orch, "create_aws_session", lambda _cfg: FakeSession())
+
+    # Functional handler returns deletion count and uses reporter
+    def handler(session: Any, region: str, dry_run: bool, reporter):  # noqa: D401, ARG001
+        reporter({
+            "phase": "plan",
+            "resource_type": "thing",
+            "id": "x",
+            "name": "n",
+            "action": "delete",
+            "status": "ok",
+            "reason": "policy",
+            "extra": {"k": "v"},
+        })
+        assert region == "us-east-1"
+        assert dry_run is False
+        return 3
+
+    # Patch service map
+    orig = orch.SERVICE_HANDLERS.copy()
+    orch.SERVICE_HANDLERS.clear()
+    orch.SERVICE_HANDLERS["funcsvc"] = handler
+
+    progress_calls: list[dict[str, int]] = []
+
+    with caplog.at_level(logging.INFO, logger=orch.__name__):
+        summary = orch.orchestrate_services(dry_run=False, progress_cb=lambda s: progress_calls.append(dict(s)))
+
+    # Restore service map
+    orch.SERVICE_HANDLERS.clear()
+    orch.SERVICE_HANDLERS.update(orig)
+
+    assert summary == {"submitted": 1, "skipped": 0, "failures": 0, "succeeded": 1, "deletions": 3}
+    # Ensure our reporter logged something
+    assert any("[funcsvc]" in rec.message for rec in caplog.records)
+    # Progress should be called at least initial and final
+    assert progress_calls[0]["pending"] >= 0
+    assert progress_calls[-1]["completed"] == 1
+
+
+def test_no_valid_services_config_raises(monkeypatch):
+    cfg = SimpleNamespace(aws=SimpleNamespace(services=["unknown"], region=["us-east-1"]))
+    monkeypatch.setattr(orch, "get_config", lambda: cfg)
+
+    with pytest.raises(ValueError, match="No valid services selected"):
+        orch.orchestrate_services()
+
+
+def test_no_regions_config_raises(monkeypatch):
+    cfg = SimpleNamespace(aws=SimpleNamespace(services=["ec2"], region=[]))
+    monkeypatch.setattr(orch, "get_config", lambda: cfg)
+
+    with pytest.raises(ValueError, match="No regions configured under aws.region"):
+        orch.orchestrate_services()
+
+
+def test_all_regions_union_empty_raises(monkeypatch):
+    cfg = SimpleNamespace(aws=SimpleNamespace(services=["funcsvc"], region=["all"]))
+
+    class FakeSession:
+        def get_available_regions(self, service_name: str):  # noqa: D401, ARG002
+            return []
+
+    monkeypatch.setattr(orch, "get_config", lambda: cfg)
+    monkeypatch.setattr(orch, "create_aws_session", lambda _cfg: FakeSession())
+
+    # Provide at least one handler to avoid previous error
+    orig = orch.SERVICE_HANDLERS.copy()
+    orch.SERVICE_HANDLERS.clear()
+
+    def handler(session: Any, region: str, dry_run: bool, reporter):  # noqa: D401, ARG001
+        return 0
+
+    orch.SERVICE_HANDLERS["funcsvc"] = handler
+
+    try:
+        with pytest.raises(ValueError, match="Unable to resolve regions for selected services"):
+            orch.orchestrate_services()
+    finally:
+        orch.SERVICE_HANDLERS.clear()
+        orch.SERVICE_HANDLERS.update(orig)
+
+
+def test_unsupported_handler_type_counts_failure(monkeypatch):
+    cfg = SimpleNamespace(aws=SimpleNamespace(services=["weird"], region=["us-east-1"]))
+
+    class FakeSession:
+        def get_available_regions(self, service_name: str):  # noqa: D401, ARG002
+            return ["us-east-1"]
+
+    monkeypatch.setattr(orch, "get_config", lambda: cfg)
+    monkeypatch.setattr(orch, "create_aws_session", lambda _cfg: FakeSession())
+
+    orig = orch.SERVICE_HANDLERS.copy()
+    orch.SERVICE_HANDLERS.clear()
+    # Use an object that is not a function or class but has a __name__ attribute
+    handler_obj = type("WeirdObj", (), {})()
+    handler_obj.__name__ = "weird_handler"  # type: ignore[attr-defined]
+    orch.SERVICE_HANDLERS["weird"] = handler_obj  # unsupported type to trigger TypeError in worker
+
+    try:
+        summary = orch.orchestrate_services(dry_run=True)
+        assert summary["failures"] == 1
+        assert summary["submitted"] == 1
+    finally:
+        orch.SERVICE_HANDLERS.clear()
+        orch.SERVICE_HANDLERS.update(orig)

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,8 @@ dependencies = [
     { name = "boto3" },
     { name = "pyfiglet" },
     { name = "pyyaml" },
+    { name = "rich" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -24,6 +26,8 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.40.1" },
     { name = "pyfiglet", specifier = ">=1.0.3" },
     { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "rich", specifier = ">=14.1.0" },
+    { name = "typer", specifier = ">=0.16.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -59,6 +63,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/d2/d914999f4a128f0f840f2a9cc8327cd98aa661d6b33b331a81a8111ab970/botocore-1.40.1.tar.gz", hash = "sha256:bdf30e2c0e8cdb939d81fc243182a6d1dd39c416694b406c5f2ea079b1c2f3f5", size = 14280398, upload-time = "2025-08-01T19:24:08.599Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/c1/aa7922c9bf74b6d6594d2430af6f854d234faff23187e269aaba89c326c8/botocore-1.40.1-py3-none-any.whl", hash = "sha256:e039774b55fbd6fe59f0f4fea51d156a2433bd4d8faa64fc1b87aee9a03f415d", size = 13940950, upload-time = "2025-08-01T19:24:03.889Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
 ]
 
 [[package]]
@@ -139,6 +155,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -237,6 +274,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.12.7"
 source = { registry = "https://pypi.org/simple" }
@@ -274,12 +324,45 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Provide a CLI entrypoint and a clean library API to allow programmatic use of awsbreaker features. This change separates CLI concerns from core library logic, introduces typed public interfaces, and adds Pydantic models for input validation and serialization. It also refactors a few modules for clearer responsibilities and testability.