### PR TITLE
chore: remove outdated classifiers from project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,6 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Topic :: Software Development :: Cloud",
-    "Topic :: System :: Cost Management",
     "Topic :: System :: Systems Administration",
     "Topic :: Utilities",
     "Typing :: Typed",


### PR DESCRIPTION
fixing outdated classifiers